### PR TITLE
brew linkapps is deprecated

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -141,8 +141,6 @@ class EmacsMac < Formula
         #{prefix}
 
       To link the application to default Homebrew App location:
-        brew linkapps
-      or:
         ln -s #{prefix}/Emacs.app /Applications
       Other ways please refer:
         https://github.com/railwaycat/homebrew-emacsmacport/wiki/Alternative-way-of-place-Emacs.app-to-Applications-directory


### PR DESCRIPTION
`brew linkapps` is deprecated.
https://github.com/Homebrew/brew/pull/1808/

So we should remove this command from install document.